### PR TITLE
Allow commands to add their own event listeners

### DIFF
--- a/src/main/java/commands/Command.java
+++ b/src/main/java/commands/Command.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import org.jetbrains.annotations.NotNull;
 import utility.EmbedUtils;
@@ -85,6 +86,11 @@ public abstract class Command {
 	 * A list of all the sub commands this command has.
 	 */
 	public ArrayList<Command> subCommands = new ArrayList<>();
+
+	/**
+	 * A list of all listeners this command has.
+	 */
+	public ArrayList<EventListener> listeners = new ArrayList<>();
 
 	/**
 	 * The default constructor for a command.

--- a/src/main/java/commands/CommandLoader.java
+++ b/src/main/java/commands/CommandLoader.java
@@ -48,6 +48,9 @@ public class CommandLoader {
         commands.add(new DailyCmd());
         commands.add(new RemoveUserCmd());
         commands.add(new HungerGamesCmd());
+        commands.stream().flatMap(command -> command.listeners.stream()).forEach(bot::addEventListener);
+        commands.stream().flatMap(command -> command.subCommands.stream())
+                .flatMap(subCommand -> subCommand.listeners.stream()).forEach(bot::addEventListener);
 
         for (Command c : commands) {
             ArrayList<String> keys = new ArrayList<>(List.of(c.aliases));


### PR DESCRIPTION
The poker game I'm creating needs to have its own event listener, because it will ask users things like "Which cards would you like to discard?" and the user will respond with saying "2 4 5". This can't be done with adding normal commands, because that would require the user to write a command (!poker discard 2 4 5), but that would be a total waste of time for the user. This change allows all commands to add custom event listeners, which they can implement in whatever way they want.