### PR TITLE
Add direct messages intent and fixes

### DIFF
--- a/src/main/java/MiloBot.java
+++ b/src/main/java/MiloBot.java
@@ -44,7 +44,8 @@ public class MiloBot {
 		JDA bot = JDABuilder.createDefault(config.getBotToken(),
 						GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_EMOJIS, GatewayIntent.GUILD_VOICE_STATES,
 						GatewayIntent.GUILD_MESSAGES, GatewayIntent.GUILD_MESSAGE_TYPING, GatewayIntent.DIRECT_MESSAGE_TYPING,
-						GatewayIntent.DIRECT_MESSAGE_TYPING, GatewayIntent.DIRECT_MESSAGE_REACTIONS, GatewayIntent.GUILD_MESSAGE_REACTIONS)
+						GatewayIntent.DIRECT_MESSAGE_TYPING, GatewayIntent.DIRECT_MESSAGE_REACTIONS, GatewayIntent.GUILD_MESSAGE_REACTIONS,
+						GatewayIntent.DIRECT_MESSAGES)
 				.setActivity(Activity.watching("Morbius"))
 				.addEventListeners(new CommandHandler(), new OnGuildJoinEvent(), new OnGuildLeaveEvent(),
 						new OnReadyEvent(), new OnUserUpdateNameEvent(), new OnButtonClick())

--- a/src/main/java/commands/CommandHandler.java
+++ b/src/main/java/commands/CommandHandler.java
@@ -4,6 +4,7 @@ import database.DatabaseManager;
 import database.queries.DailiesTableQueries;
 import database.queries.PrefixTableQueries;
 import database.queries.UsersTableQueries;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -41,6 +42,10 @@ public class CommandHandler extends ListenerAdapter {
 
 	@Override
 	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+		if (event.getChannelType() != ChannelType.TEXT) {
+			return;
+		}
+
 		// ignore messages from other bots or itself
 		if (event.getMessage().getAuthor().isBot()) {
 			return;

--- a/src/main/java/commands/CommandHandler.java
+++ b/src/main/java/commands/CommandHandler.java
@@ -4,6 +4,7 @@ import database.DatabaseManager;
 import database.queries.DailiesTableQueries;
 import database.queries.PrefixTableQueries;
 import database.queries.UsersTableQueries;
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -13,7 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import utility.User;
 
+import java.awt.*;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -135,8 +138,13 @@ public class CommandHandler extends ListenerAdapter {
 
 	@Override
 	public void onSlashCommand(@NotNull SlashCommandEvent event) {
-		// ignore commands not from a guild
+		// send error message for commands not from a guild (commands from DMs)
 		if (event.getGuild() == null) {
+			EmbedBuilder eb = new EmbedBuilder();
+			eb.setColor(Color.RED);
+			eb.setTitle("Error");
+			eb.setDescription("Commands cannot be used in DMs.");
+			event.replyEmbeds(eb.build()).queue();
 			return;
 		}
 		AtomicBoolean commandFound = new AtomicBoolean(false);

--- a/src/main/java/commands/CommandLoader.java
+++ b/src/main/java/commands/CommandLoader.java
@@ -17,7 +17,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
-import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -58,12 +57,11 @@ public class CommandLoader {
             commandList.put(keys, c);
         }
 
-        CommandListUpdateAction slashCommands = bot.updateCommands();
+        bot.updateCommands()
+                .addCommands(new CommandData("help", "Shows the user a list of available commands.")
+                        .addOption(OptionType.STRING, "command", "The command you want information about.", false))
 
-        slashCommands.addCommands(new CommandData("help", "Shows the user a list of available commands.")
-                .addOption(OptionType.STRING, "command", "The command you want information about.", false));
-
-        slashCommands.addCommands(new CommandData("encounter", "D&D 5e encounter generator.")
+                .addCommands(new CommandData("encounter", "D&D 5e encounter generator.")
                 .addSubcommands(new SubcommandData("generate", "Generate a random encounter for the given inputs.")
                         .addOptions(new OptionData(OptionType.INTEGER, "size", "The size of the party.")
                                 .setRequired(true)
@@ -82,9 +80,9 @@ public class CommandLoader {
                                         new Choice("other plane", "other plane"), new Choice("underground", "underground"),
                                         new Choice("water", "water")
                                 ))
-                ));
+                ))
 
-        slashCommands.addCommands(new CommandData("wordle", "Wordle brought to discord.")
+                .addCommands(new CommandData("wordle", "Wordle brought to discord.")
                 .addSubcommands(
                         new SubcommandData("leaderboard", "View the wordle leaderboards.")
                                 .addOptions(new OptionData(OptionType.STRING, "leaderboard", "The leaderboard you want to view.", true).addChoices(
@@ -93,33 +91,32 @@ public class CommandLoader {
                                         new Choice("current streak", "currentStreak")
                                 )),
                         new SubcommandData("play", "Play a game of wordle."),
-                        new SubcommandData("stats", "View your own blackjack statistics.")));
+                        new SubcommandData("stats", "View your own blackjack statistics.")))
 
-        slashCommands.addCommands(new CommandData("bug", "Add bugs to the bots issue tracker, or view them.")
+                .addCommands(new CommandData("bug", "Add bugs to the bots issue tracker, or view them.")
                 .addSubcommands(List.of(
                         new SubcommandData("report", "Report a bug you found."),
                         new SubcommandData("list", "Shows a list of all reported bugs."),
                         new SubcommandData("view", "Lookup a specific bug on the issue tracker.").addOptions(
                                 new OptionData(OptionType.INTEGER, "id", "The id of the bug you want to view", true)
-                        ))));
+                        ))))
 
-        slashCommands.addCommands(new CommandData("invite", "Sends an invite link to add the bot to another server."));
+                .addCommands(new CommandData("invite", "Sends an invite link to add the bot to another server."))
 
-        slashCommands.addCommands(new CommandData("profile", "View your own or someone else's profile.")
-                .addOption(OptionType.USER, "user", "The user you want to view the profile of.", false));
+                .addCommands(new CommandData("profile", "View your own or someone else's profile.")
+                        .addOption(OptionType.USER, "user", "The user you want to view the profile of.", false))
 
-        slashCommands.addCommands(new CommandData("prefix", "Change the prefix of the guild you're in.")
-                .addOption(OptionType.STRING, "prefix", "The new prefix.", true));
+                .addCommands(new CommandData("prefix", "Change the prefix of the guild you're in.")
+                    .addOption(OptionType.STRING, "prefix", "The new prefix.", true))
 
-        slashCommands.addCommands(new CommandData("blackjack", "Blackjack brought to discord").addSubcommands(
-                new SubcommandData("play", "Play a game of blackjack on discord.")
+                .addCommands(new CommandData("blackjack", "Blackjack brought to discord").addSubcommands(
+                    new SubcommandData("play", "Play a game of blackjack on discord.")
                         .addOptions(new OptionData(OptionType.INTEGER, "bet", "The amount of money you want to bet.", false)
                                 .setRequiredRange(1, 10000)),
-                new SubcommandData("stats", "View your own blackjack statistics.")
-        ));
+                    new SubcommandData("stats", "View your own blackjack statistics.")))
 
-        slashCommands.addCommands(new CommandData("daily", "Collect your daily reward."));
+                .addCommands(new CommandData("daily", "Collect your daily reward."))
 
-        slashCommands.queue();
+                .queue();
     }
 }

--- a/src/main/java/commands/bot/bug/BugReportCmd.java
+++ b/src/main/java/commands/bot/bug/BugReportCmd.java
@@ -3,6 +3,7 @@ package commands.bot.bug;
 import commands.Command;
 import commands.SubCmd;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -71,6 +72,10 @@ public class BugReportCmd extends Command implements SubCmd {
 				ListenerAdapter listener = new ListenerAdapter() {
 					@Override
 					public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+						if (event.getChannelType() != ChannelType.TEXT) {
+							return;
+						}
+
 						if (event.getAuthor().getId().equals(author.getId())) {
 							event.getJDA().removeEventListener(this);
 							if (event.getMessage().getContentRaw().toLowerCase(Locale.ROOT).equals("cancel")) {

--- a/src/main/java/commands/games/wordle/WordleLeaderboardCmd.java
+++ b/src/main/java/commands/games/wordle/WordleLeaderboardCmd.java
@@ -24,7 +24,7 @@ import java.util.Locale;
  */
 public class WordleLeaderboardCmd extends Command implements SubCmd {
 
-	private static final DatabaseManager manager = DatabaseManager.getInstance();;
+	private static final DatabaseManager manager = DatabaseManager.getInstance();
 
 	public WordleLeaderboardCmd() {
 		this.commandName = "leaderboard";

--- a/src/main/java/commands/games/wordle/WordlePlayCmd.java
+++ b/src/main/java/commands/games/wordle/WordlePlayCmd.java
@@ -6,6 +6,7 @@ import database.DatabaseManager;
 import database.queries.WordleTableQueries;
 import games.Wordle;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -76,6 +77,10 @@ public class WordlePlayCmd extends Command implements SubCmd {
 		ListenerAdapter listener = new ListenerAdapter() {
 			@Override
 			public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+				if (event.getChannelType() != ChannelType.TEXT) {
+					return;
+				}
+
 				String id = event.getAuthor().getId();
 				if (authorId.equals(id)) {
 					EmbedBuilder newEmbed = new EmbedBuilder();

--- a/src/main/java/games/HungerGames.java
+++ b/src/main/java/games/HungerGames.java
@@ -173,7 +173,7 @@ public class HungerGames {
     public Globals getGlobals() {
         Globals globals = JsePlatform.standardGlobals();
         LuaValue gameLua = CoerceJavaToLua.coerce(this);
-        globals.set("game", gameLua);;
+        globals.set("game", gameLua);
         return globals;
     }
 


### PR DESCRIPTION
- Added direct messages intent. Added checks to onMessageReceived event handlers to check if message
is from a text channel (guild channel), because now this event fires
also when private messages are received.
- Fix slash command loader to load the commands the correct way, using method chaining. IntelliJ gave a warning that the program didn't do anything with the return value, even though the addCommands() is annotated with @CheckReturnValue.
- Remove unnecessary semicolons in two places.