### PR TITLE
Fix pom.xml issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
                         <target>16</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,14 +12,6 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>16</source>
-                        <target>16</target>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M7</version>
                 </plugin>
@@ -28,8 +20,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,6 @@
             <version>8.0.29</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.9.0</version>


### PR DESCRIPTION
1.
According to the JUnit package on [its repository](https://mvnrepository.com/artifact/junit/junit), it has moved to junit-jupiter-api.
![image](https://user-images.githubusercontent.com/30361931/183719398-91b92501-fd25-4ea8-83ec-6ef74e5f860d.png)
Which, according to [this](https://stackoverflow.com/questions/48448331/difference-between-junit-jupiter-api-and-junit-jupiter-engine) Stack Overflow answer, is included in junit-jupiter.
![image](https://user-images.githubusercontent.com/30361931/183720217-07956182-c4c6-41b5-98c4-f2cce11c14ef.png)
You have junit-jupiter as a dependency, so junit is simply not needed.

2.
Added maven surefire plugin to run the tests.

3.
Set project encoding to UTF-8, because maven was giving a warning that build platform is dependent, because source encoding is not set.

4.
Set project Java version correctly, because the version was defined in both project properties and the plugin configuration, and they were different. I solved this by setting the version only at the properties section to 16.